### PR TITLE
DTE-163 Parser Regression Test

### DIFF
--- a/testing/parser_testing/README.md
+++ b/testing/parser_testing/README.md
@@ -1,0 +1,68 @@
+# Testing
+
+To execute the parser test script:
+
+1. Enable a Python virtual environment; e.g. if one is configured in the
+    project's root directory (e.g. `python3 -m venv .venv`) run:
+
+    ```bash
+    . ../../.venv/bin/activate
+    ```
+
+2. Ensure required packages are installed (e.g. `pip3 install boto3`)
+
+3. Identify the location of test documents in S3; e.g.:
+
+    ```bash
+    % aws s3 ls "${PARSER_TEST_S3_BUCKET}/parser/"
+        PRE fail/
+        PRE ok/
+    %
+    ```
+
+4. Set values for the following environment variables:
+
+    ```bash
+    export PARSER_TEST_S3_BUCKET=''
+    export PARSER_TEST_S3_PATH_DATA_OK='parser/ok/'
+    export PARSER_TEST_S3_PATH_DATA_FAIL='parser/fail/'
+    export PARSER_TEST_S3_PATH_OUTPUT='parser/output-tmp/'
+    export PARSER_TEST_TESTDATA_SUFFIX='.docx'
+    export PARSER_TEST_LAMBDA='test_judgment_parser'
+    ```
+
+5. Ensure your AWS CLI environment is configured to access your S3 test data
+    (e.g. `export AWS_PROFILE='...'`)
+
+6. Run the tests:
+
+    ```bash
+    python3 test_parser_lambda_fn.py
+    ```
+
+    This will exit with status 0 on success. It will fail if a document in the
+    "ok" directory has a parser error, or a document in the "fail" directory
+    does not have a parser error. 
+
+Parser outputs for each test run are grouped under a timestamped directory;
+for example, here are 4 test run folders:
+
+```bash
+$ aws s3 ls "${PARSER_TEST_S3_BUCKET}/parser/output-tmp/"
+      PRE 2022-05-24T07:34:00.741705+00:00/
+% aws s3 ls "${PARSER_TEST_S3_BUCKET}/parser/output-tmp/2022-05-24T07:34:00.741705+00:00/" 
+      PRE 2022-05-24T07:34:01.792037+00:00-19972208-e54d-4595-9d7a-a6e990913833/
+      PRE 2022-05-24T07:34:06.211549+00:00-cfec61f5-7e8b-478e-a693-1a7cf63f7beb/
+      PRE 2022-05-24T07:34:06.848889+00:00-35902e29-5106-4827-8850-ea7bd958a949/
+      PRE 2022-05-24T07:34:07.631693+00:00-222b6848-8287-4c8b-9362-24dd86dbc2fa/
+      PRE 2022-05-24T07:34:08.716847+00:00-76016832-7d0c-4a6b-b233-5b19e97673f9/
+      PRE 2022-05-24T07:34:09.341091+00:00-9bec390b-84a6-4cf0-9c35-723b7253fe8e/
+      PRE 2022-05-24T07:34:11.263554+00:00-fe8252a5-bce4-4425-b92c-99e180babd65/
+      PRE 2022-05-24T07:34:14.175297+00:00-4eff5003-c420-442f-a666-368c31c7ab0c/
+% aws s3 ls "${PARSER_TEST_S3_BUCKET}/parser/output-tmp/2022-05-24T07:34:00.741705+00:00/2022-05-24T07:34:14.175297+00:00-4eff5003-c420-442f-a666-368c31c7ab0c/"
+2022-05-24 08:34:15     122513 2022-05-24T07:34:14.175297+00:00-4eff5003-c420-442f-a666-368c31c7ab0c.xml
+2022-05-24 08:34:16       8003 image1.png
+2022-05-24 08:34:16        182 metadata.json
+2022-05-24 08:34:16       1415 parser.log
+%
+```

--- a/testing/parser_testing/README.md
+++ b/testing/parser_testing/README.md
@@ -45,7 +45,7 @@ To execute the parser test script:
     does not have a parser error. 
 
 Parser outputs for each test run are grouped under a timestamped directory;
-for example, here are 4 test run folders:
+for example:
 
 ```bash
 $ aws s3 ls "${PARSER_TEST_S3_BUCKET}/parser/output-tmp/"

--- a/testing/parser_testing/example_use.sh
+++ b/testing/parser_testing/example_use.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+main() {
+  if [ $# -ne 1 ]; then
+    echo 'Usage: s3_bucket'
+    return 1
+  fi
+
+  export PYTHONPATH='../../lambda_functions/te-editorial-integration:../../s3_lib'
+  export PARSER_TEST_S3_BUCKET="${1}"
+  export PARSER_TEST_S3_PATH_DATA_OK='parser/ok/'
+  export PARSER_TEST_S3_PATH_DATA_FAIL='parser/fail/'
+  export PARSER_TEST_S3_PATH_OUTPUT='parser/output-tmp/'
+  export PARSER_TEST_TESTDATA_SUFFIX='.docx'
+  export PARSER_TEST_LAMBDA='test_judgment_parser'
+
+  python3 test_parser_lambda_fn.py
+}
+
+main "$@"

--- a/testing/parser_testing/example_use.sh
+++ b/testing/parser_testing/example_use.sh
@@ -5,7 +5,6 @@ main() {
     return 1
   fi
 
-  export PYTHONPATH='../../lambda_functions/te-editorial-integration:../../s3_lib'
   export PARSER_TEST_S3_BUCKET="${1}"
   export PARSER_TEST_S3_PATH_DATA_OK='parser/ok/'
   export PARSER_TEST_S3_PATH_DATA_FAIL='parser/fail/'

--- a/testing/parser_testing/test_parser_lambda_fn.py
+++ b/testing/parser_testing/test_parser_lambda_fn.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Requires the following environment variables be set:
+* PARSER_TEST_S3_BUCKET         : S3 bucket holding test docx files
+* PARSER_TEST_S3_PATH_DATA_OK   : Path in S3 bucket holding test docx files expected to pass
+* PARSER_TEST_S3_PATH_DATA_FAIL : Path in S3 bucket holding test docx files expected to fail
+* PARSER_TEST_S3_PATH_OUTPUT    : Path to which parser writes output files in the S3 bucket
+* PARSER_TEST_TESTDATA_SUFFIX   : Filter to use only S3 objects that end with this string
+* PARSER_TEST_LAMBDA            : The name of the parser lambda function to test
+"""
+import logging
+from s3_lib import common_lib
+import boto3
+import json
+from datetime import datetime, timezone
+import uuid
+
+
+# Set global logging options; AWS environment may override this though
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+
+# Instantiate logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class ParserTester():
+    init_ts = datetime.now(tz=timezone.utc)
+
+    s3_bucket = common_lib.get_env_var(
+            'PARSER_TEST_S3_BUCKET', must_exist=True, must_have_value=True)
+
+    # e.g. 'parser/ok/'
+    s3_path_test_data_ok = common_lib.get_env_var(
+            'PARSER_TEST_S3_PATH_DATA_OK', must_exist=True, must_have_value=True)
+
+    # e.g. 'parser/fail/'
+    s3_path_test_data_fail = common_lib.get_env_var(
+            'PARSER_TEST_S3_PATH_DATA_FAIL', must_exist=True, must_have_value=True)
+
+    # e.g. 'parser/output/'
+    s3_path_parser_output = common_lib.get_env_var(
+            'PARSER_TEST_S3_PATH_OUTPUT', must_exist=True, must_have_value=True) + f'{init_ts.isoformat()}/'
+
+    # e.g. '.docx'
+    testdata_suffix = common_lib.get_env_var(
+            'PARSER_TEST_TESTDATA_SUFFIX', must_exist=True, must_have_value=True)
+
+    # e.g. 'test_judgment_parser'
+    test_lambda = common_lib.get_env_var(
+            'PARSER_TEST_LAMBDA', must_exist=True, must_have_value=True)
+
+    s3_presigned_url_expiry = 60
+    s3_resource = boto3.resource('s3')
+    s3_client = boto3.client('s3')
+
+    def __init__(self):
+        s3_bucket = self.s3_resource.Bucket(self.s3_bucket)
+
+        test_docx_files_ok = s3_bucket.objects.filter(Prefix=self.s3_path_test_data_ok)
+        self.docx_files_ok = [
+            i.key
+            for i in test_docx_files_ok
+            if i.key.endswith(self.testdata_suffix)
+        ]
+
+        test_docx_files_fail = s3_bucket.objects.filter(Prefix=self.s3_path_test_data_fail)
+        self.docx_files_fail = [
+            i.key
+            for i in test_docx_files_fail
+            if i.key.endswith(self.testdata_suffix)
+        ]
+
+
+    def generate_presigned_url(self, s3_path):
+        logger.info(f'generate_presigned_url: s3_path={s3_path}')
+        return self.s3_client.generate_presigned_url(
+            'get_object',
+            Params={'Bucket': self.s3_bucket, 'Key': s3_path},
+            ExpiresIn=self.s3_presigned_url_expiry)
+
+
+    def generate_parser_input(self, s3_path: str) -> str:
+        ts = datetime.now(tz=timezone.utc)
+        consignment_reference = f'{ts.isoformat()}-{uuid.uuid4()}'
+        output_path = self.s3_path_parser_output + consignment_reference + '/'
+
+        parser_input = {
+            'parser-inputs': {
+                'consignment-reference': consignment_reference,
+                's3-bucket': self.s3_bucket,
+                'document-url': self.generate_presigned_url(s3_path=s3_path),
+                'attachment-urls': [],
+                's3-output-prefix': output_path
+            }
+        }
+
+        return json.dumps(parser_input)
+
+
+    def run_test(self, s3_path: str, expect_parser_error: bool) -> tuple:
+        """
+        Run test Lambda and return tuple indicating test success and result.
+        """
+        logger.info(f'run_parser_test start: s3_path={s3_path}')
+
+        s3_client = boto3.client('lambda')
+        payload = self.generate_parser_input(s3_path=s3_path)
+        logger.info(f'payload={payload}')
+
+        parser_invoke_response = s3_client.invoke(
+                FunctionName=self.test_lambda,
+                Payload=payload
+        )
+
+        logger.info(f'parser_invoke_response={parser_invoke_response}')
+        result = json.load(parser_invoke_response['Payload'])
+        logger.info(f'result={result}')
+
+        if len(result['parser-outputs']['error-messages']) > 0:
+            # Parser reported an error; OK if error was expected
+            if expect_parser_error:
+                logger.info('Expected parser error')
+                return True, result
+            else:
+                logger.info('Unexpected parser error')
+                return False, result
+        else:
+            # Parser did not report an error; OK if error was not expected
+            if expect_parser_error:
+                logger.info('Did not get expected parser error')
+                return False, result
+            else:
+                logger.info('Parser ran as expected without error')
+                return True, result
+
+
+    def create_record(
+            self,
+            s3_path: str,
+            result: dict,
+            ran_ok: bool,
+            expected_parser_error: bool
+    ) -> dict:
+        return {
+            's3_bucket': self.s3_bucket,
+            'docx': s3_path,
+            'result': result,
+            'expected_parser_error': expected_parser_error,
+            'ran_ok': ran_ok
+        }
+
+
+    def run_tests(self):
+        logger.info('run_tests')
+
+        result_list_test_ok = []
+        result_list_test_fail = []
+
+        # Test documents that should pass
+        logger.info('Running tests for documents that should parse')
+        for s3_path in self.docx_files_ok:
+            ran_ok, result = self.run_test(
+                    s3_path=s3_path,
+                    expect_parser_error=False)
+
+            record = self.create_record(s3_path=s3_path, result=result, ran_ok=ran_ok, expected_parser_error=False)
+
+            if ran_ok:
+                result_list_test_ok.append(record)
+            else:
+                result_list_test_fail.append(record)
+
+        # Test documents that should fail
+        logger.info('Running tests for documents that should fail to parse')
+        for s3_path in self.docx_files_fail:
+            ran_ok, result = self.run_test(
+                    s3_path=s3_path,
+                    expect_parser_error=True)
+
+            record = self.create_record(s3_path=s3_path, result=result, ran_ok=ran_ok, expected_parser_error=True)
+
+            if ran_ok:
+                result_list_test_ok.append(record)
+            else:
+                result_list_test_fail.append(record)
+
+        return result_list_test_ok, result_list_test_fail
+
+
+def main():
+    logger.info(f'main start')
+    pt = ParserTester()
+    result_list_ok, result_list_fail = pt.run_tests()
+    logger.info(f'result_list_ok={result_list_ok}')
+    logger.info(f'result_list_fail={result_list_fail}')
+
+    if len(result_list_fail) > 0:
+        raise ValueError('Parser regression tests failed: '
+                f'result_list_ok={result_list_ok} '
+                f'result_list_fail={result_list_fail}')
+
+    logger.info('main end')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added script and documentation to run a pre-configured Judgment Parser Lambda function against a set of OK documents and a set of FAIL documents; the script checks that:

* Documents in the OK set do not report a parser error
* Documents in the FAIL set do report a parser error

The script does not currently validate any other parser output values.

The following environment variables are used to drive the script:
```
export PARSER_TEST_S3_BUCKET=''
export PARSER_TEST_S3_PATH_DATA_OK='parser/ok/'
export PARSER_TEST_S3_PATH_DATA_FAIL='parser/fail/'
export PARSER_TEST_S3_PATH_OUTPUT='parser/output-tmp/'
export PARSER_TEST_TESTDATA_SUFFIX='.docx'
export PARSER_TEST_LAMBDA='test_judgment_parser'
```