### PR TITLE
DTE-166 CodePipeline automated parser update

### DIFF
--- a/codepipeline/parser-pipeline/check_auto_deploy_permitted.sh
+++ b/codepipeline/parser-pipeline/check_auto_deploy_permitted.sh
@@ -18,7 +18,7 @@ main() {
 
   local tmp
   tmp="$(echo "${v_old}" | awk '{split($0, values, "."); print values[1]}')"
-  local v_old_major="${tmp:-0}"  
+  local v_old_major="${tmp:-0}"
   tmp="$(echo "${v_old}" | awk '{split($0, values, "."); print values[2]}')"
   local v_old_minor="${tmp:-0}"
   tmp="$(echo "${v_old}" | awk '{split($0, values, "."); print values[3]}')"
@@ -32,7 +32,7 @@ main() {
   tmp="$(echo "${v_new}" | awk '{split($0, values, "."); print values[3]}')"
   local v_new_patch="${tmp:-0}"
   local v_new_parsed="${v_new_major}.${v_new_minor}.${v_new_patch}"
-  
+
   local version_msg="(${v_old_parsed} -> ${v_new_parsed})"
 
   printf 'v_old_in=%s v_new_in=%s\n' "${v_old_in}" "${v_new_in}"
@@ -54,7 +54,7 @@ main() {
     printf 'Automatic downgrade of parser version is not permitted %s\n' "${version_msg}"
     return 1
   fi
-  
+
   printf 'Automatic upgrade of parser version may proceed %s\n' "${version_msg}"
 }
 

--- a/codepipeline/parser-pipeline/set_env_parser_version.sh
+++ b/codepipeline/parser-pipeline/set_env_parser_version.sh
@@ -52,7 +52,7 @@ main() {
   fi
 
   # Use sed to replace only tre_run_judgment_parser version
-  str_find='tre_run_judgment_parser = "'
+  local str_find='tre_run_judgment_parser = "'
   new_value="$(
     printf '%s' "${aws_parameter_store_value}" | \
     sed -e "s/\(${str_find}\)[^\"]*/\1${new_parser_version}/"
@@ -74,9 +74,11 @@ main() {
     --value "${new_value}" \
     --overwrite;
   then
-    printf 'Parameter %s has been updated\n' "${parameter_name}"
+    printf 'Parameter %s has been updated from %s to %s\n' \
+        "${parameter_name}" "${current_parser_version}" "${new_parser_version}"
   else
-    printf 'Error updating parameter %s\n' "${parameter_name}"
+    printf 'Error updating parameter %s from %s to %s\n' \
+        "${parameter_name}" "${current_parser_version}" "${new_parser_version}"
     return 1
   fi
 }

--- a/codepipeline/parser-pipeline/set_env_parser_version.sh
+++ b/codepipeline/parser-pipeline/set_env_parser_version.sh
@@ -13,7 +13,7 @@ main() {
 
   printf 'parameter_name=%s new_parser_version=%s\n' \
       "${parameter_name}" "${new_parser_version}"
-  
+
   printf 'Getting parameter %s ...\n' "${parameter_name}"
   local aws_parameter_store_value
   aws_parameter_store_value="$(
@@ -57,13 +57,13 @@ main() {
     printf '%s' "${aws_parameter_store_value}" | \
     sed -e "s/\(${str_find}\)[^\"]*/\1${new_parser_version}/"
   )"
-  #         s/                                                : search        
-  #           \(                                              : start group 1 
-  #                        \)                                 : end group 1   
-  #                          [^\"]*                           : match until " 
-  #                                /                          : replacement   
-  #                                 \1                        : group 1       
-  #                                                        /  : end           
+  #         s/                                                : search
+  #           \(                                              : start group 1
+  #                        \)                                 : end group 1
+  #                          [^\"]*                           : match until "
+  #                                /                          : replacement
+  #                                 \1                        : group 1
+  #                                                        /  : end
   # https://stackoverflow.com/a/49847921
 
   printf '\nnew_value\n---------\n%s\n\n' "${new_value}"


### PR DESCRIPTION
Added scripts to automatically update the parser version in AWS Parameter Store (this is currently stored in a Terraform variable format).

The script gets the current value, checks the major version is not being changed (as major version changes are not to be automatically rolled out) and also ensured the parser version is not being downgraded (in case an old parser version tag is added at some point in the future) or re-released (i.e. re-deploy of same version is not allowed); it then updates the parser version in the parameter string and writes this back to Parameter Store.

To use, run the `set_env_parser_version.sh` script and pass 2 arguments; the Parameter Store variable name and the new parser version; for example:

```
./set_env_parser_version.sh '/tmp/foo/a' 'v84.168.42'
./set_env_parser_version.sh 'dev-tfvars' 'v0.6.1'
./set_env_parser_version.sh 'test-tfvars' 'v0.6.1'
```

The script exits with status code zero on success, or non-zero if the update is not permitted or fails.