### PR TITLE
DTE-202: add checksum of output.tar.gz

### DIFF
--- a/lambda_functions/tre-editorial-integration/version.sh
+++ b/lambda_functions/tre-editorial-integration/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 docker_image_name=tre-editorial-integration
-docker_image_tag=0.0.19
+docker_image_tag=0.0.20
 # shellcheck disable=SC2034  # var imported elsewhere
 docker_image="${docker_image_name}":"${docker_image_tag}"

--- a/testing/te_editorial_integration/test_step_editorial_int.py
+++ b/testing/te_editorial_integration/test_step_editorial_int.py
@@ -10,4 +10,4 @@ event=sys.argv[1]
 context=None
 
 output = tre_editorial_integration.handler(json.loads(event), context)
-print(f'te_editorial_integration output:\n{json.dumps(output, indent=4)}')
+print(f'tre_editorial_integration output:\n{json.dumps(output, indent=4)}')

--- a/testing/tre_module_test/tests/test_tdr_bagit_function_error.py
+++ b/testing/tre_module_test/tests/test_tdr_bagit_function_error.py
@@ -19,7 +19,7 @@ def test_tdr_bagit_function_error(ct: ConsignmentTester):
     """
     logger.info('### test_tdr_bagit_function_error start ###################')
     test_start_datetime = datetime.now(tz=timezone.utc)
-    cr = 'TEST-FUNCTION-ERROR-PATH-BAGIT'
+    cr = 'TEST-FUNC-ERR-PATH-BAGIT'
     sqs_result = ct.send_sqs_message_tdr(sqs_message=f'{{"consignment-reference": "{cr}"}}')
     logger.info(f'sqs_result={sqs_result}')
     executions = ct.get_step_function_executions(


### PR DESCRIPTION
For editorial output:
- adds a checksum file alongside editorial-output.tar.gz in bucket
- add url for that file in output.json (both first processing and on any editorial retries)

Have checked with caselaw that addition to the json will not break receiving code and all ok (they _"specifically look for the s3-folder-url when ingesting the tar file"_)
