### PR TITLE
Support param store for SF update list

### DIFF
--- a/codepipeline/lambda-deploy/README.md
+++ b/codepipeline/lambda-deploy/README.md
@@ -1,9 +1,84 @@
-# ecr_version_filter.py
+# Lambda Deploy
 
-Setup Python virtual environment (run `deactivate` to deactivate it):
+Scripts to automate Step Function Lambda Function deployment.
 
-```
+There are 2 parts:
+
+1. Detecting, building and deploying new Docker image versions to ECR
+2. Updating the Docker image version(s) used by Step Function Lambda Functions
+
+# Prerequisites
+
+## Python Libraries
+
+To install the required libraries ([`requirements.txt`](requirements.txt)):
+
+```bash
+# Optionally setup a virtual environment (run deactivate to deactivate it)
 python3 -m venv .venv
 . ./.venv/bin/activate
-pip install -r codepipeline/auto-lambda-deploy/requirements.txt
+
+# Install the required libraries
+pip install -r codepipeline/lambda-deploy/requirements.txt
 ```
+
+# Deploying new Docker images to ECR
+
+Run the following to build and deploy to ECR any Docker images that have a
+name and version (in their corresponding `version.sh` file) that is not in
+ECR:
+
+```bash
+# Set for the target environment
+export AWS_PROFILE=
+AWS_ECR_REGION=
+
+cd codepipeline/lambda-deploy
+deploy_images_to_ecr.sh "${AWS_ECR_REGION}"
+```
+
+> Script [`deploy_images_to_ecr.sh`](deploy_images_to_ecr.sh) calls script
+  [`ecr_version_filter.py`](ecr_version_filter.py).
+
+# Updating Step-Function Lambda-Function Docker image versions
+
+Run the following to update the Lambda Function Docker image versions for a
+set of Step Functions:
+
+```bash
+# Set these for your environment
+export AWS_PROFILE=
+SF_TF_VAR_KEY_NAME='step-function-tfvar-version-keys-list'
+TARGET_PARAMETER='target-env-tfvars'
+LAMBDA_FUNCTION_DIR='../../lambda_functions'
+
+# Get list of Step Functions to update from Parameter Store
+SF_TF_VAR_KEY_LIST="$(
+  aws ssm get-parameter \
+    --name "${SF_TF_VAR_KEY_NAME}" \
+    --with-decryption \
+    --query 'Parameter.Value' \
+    --output text \
+)"
+
+./update_step_functions.sh \
+  "${SF_TF_VAR_KEY_LIST}" \
+  "${TARGET_PARAMETER}" \
+  "${LAMBDA_FUNCTION_DIR}"
+```
+
+The records in Parameter Store parameter `SF_TF_VAR_KEY_NAME` define the
+Terraform variable keys used to auto update 1 or more Step-Function
+Lambda-Function Docker image versions.
+
+The following format must be used, with 1 record per line:
+
+```
+sf-version-key-name-1,sf-lambda-version-dict-name-1
+sf-version-key-name-n,sf-lambda-version-dict-name-n
+```
+
+Where `sf-version-key-name` specifies a Step Function version variable name
+(holding a string version value) and `sf-lambda-version-dict-name` specifies a
+Step Function Lambda Function Docker image version variable (which returns a
+dictionary of Lambda Function Docker image versions).

--- a/codepipeline/lambda-deploy/update_step_functions.sh
+++ b/codepipeline/lambda-deploy/update_step_functions.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+
+function update_pipeline_step_functions() {
+  # Iterate over a list of step function key lists (one list per line). Use
+  # the values in each key list (a pair of comma separated strings) to update
+  # the respective step function lambda variables by running script
+  # update_sf_lambda_versions.py.
+  #
+  # Arguments:
+  #
+  # step_function_key_list : Defines which step function(s) will be updated;
+  #                          expected format is:
+  #
+  #                           sf_ver_key_1,sf_lambda_ver_key_1
+  #                           ...
+  #                           sf_ver_key_n,sf_lambda_ver_key_n
+  # target_parameter       : AWS Parameter Store parameter name
+  # lambda_functions_dir   : Path to lambda_functions dir
+  if [ $# -ne 3 ]; then
+    printf 'Usage: update_pipeline_step_functions %s %s %s\n' \
+        "step_function_key_list" "target_parameter" "lambda_functions_dir"
+    return 1
+  fi
+
+  local step_function_key_list="$1"
+  local target_parameter="$2"
+  local lambda_functions_dir="$3"
+
+  # Iterate over records. Append newline to input to ensure process a last row
+  # with no newline. Use grep to ignore invalid/empty lines.
+  # grep '^.\+,.\+'
+  #       ^         : ^ = start of line
+  #        .\+      : . = any char; \+ = 1+ times
+  #           ,     : , = literal "," char
+  #            .\+  : . = any char; \+ = 1+ times
+  local record
+  printf '%s\n' "${step_function_key_list}" \
+      | grep '^.\+,.\+' \
+      | while read -r record
+  do
+    printf 'record=%s\n' "${record}"
+    local kv_array
+    IFS=',' read -r -a kv_array <<< "${record}"
+    printf 'kv_array[0]=%s kv_array[1]=%s\n' "${kv_array[0]}" "${kv_array[1]}"
+
+    printf 'Invoking: ./update_sf_lambda_versions.py "%s" "%s" "%s" "%s"\n' \
+        "${target_parameter}" \
+        "${kv_array[0]}" \
+        "${kv_array[1]}" \
+        "${lambda_functions_dir}"
+
+    ./update_sf_lambda_versions.py \
+        "${target_parameter}" \
+        "${kv_array[0]}" \
+        "${kv_array[1]}" \
+        "${lambda_functions_dir}"
+  done
+}
+
+update_pipeline_step_functions "${@}"


### PR DESCRIPTION
Added script to iterate over list of Step Function TFVAR version keys to update Step-Function Lambda-Function Docker images.

Storing the TFVAR version keys in Parameter Store allows the automated update of new Step Functions to be configured by updating the Parameter Store record (the code-pipeline does not need to change).

Updated `README.md` to reflect the above additions.