### PR TITLE
Remove retry and add developer test scripts

### DIFF
--- a/lambda_functions/tre-sqs-sf-trigger/tre_sqs_sf_trigger.py
+++ b/lambda_functions/tre-sqs-sf-trigger/tre_sqs_sf_trigger.py
@@ -16,13 +16,12 @@ logger.setLevel(logging.INFO)
 
 PATH_SEPARATOR = '.'
 NAME_SEPARATOR = '-'
-UNKNOWN_VALUE = '?'
+UNKNOWN_VALUE = '_'
 EVENT_SOURCE_ARN = 'eventSourceARN'
 KEY_RECORDS = 'Records'
 KEY_UUIDS = 'UUIDs'
 TRE_STATE_MACHINE_ARN = os.environ['TRE_STATE_MACHINE_ARN']
 TRE_CONSIGNMENT_KEY_PATH = os.environ['TRE_CONSIGNMENT_KEY_PATH']
-TRE_RETRY_KEY_PATH = os.environ['TRE_RETRY_KEY_PATH']
 
 client = boto3.client('stepfunctions')
 
@@ -65,7 +64,6 @@ def get_latest_uuid(tre_message: dict) -> str:
 def handler(event, context):
     logger.info(f'TRE_STATE_MACHINE_ARN={TRE_STATE_MACHINE_ARN}')
     logger.info(f'TRE_CONSIGNMENT_KEY_PATH={TRE_CONSIGNMENT_KEY_PATH}')
-    logger.info(f'TRE_RETRY_KEY_PATH={TRE_RETRY_KEY_PATH}')
     logger.info(f'event:\n{event}')
 
     if KEY_RECORDS not in event:
@@ -92,14 +90,6 @@ def handler(event, context):
     if consignment_ref is None:
         consignment_ref = UNKNOWN_VALUE
 
-    # Get retry number for the execution name
-    retry_keys = list(reversed(TRE_RETRY_KEY_PATH.split(PATH_SEPARATOR)))
-    logger.info(f'retry_keys={retry_keys}')
-    retry_number = get_dict_key_value(source=tre_message, key_path=retry_keys)
-    logger.info(f'retry_number={retry_number}')
-    if retry_number is None:
-        retry_number = UNKNOWN_VALUE
-
     # Get event source (SQS queue name) for the execution name
     event_source = UNKNOWN_VALUE
     if EVENT_SOURCE_ARN in event_record:
@@ -111,7 +101,7 @@ def handler(event, context):
     logger.info(f'latest_uuid={latest_uuid}')
 
     # Build execution name
-    name_list = [consignment_ref, str(retry_number), event_source, latest_uuid]
+    name_list = [consignment_ref, event_source, latest_uuid]
     logger.info(f'name_list={name_list}')
     execution_name = NAME_SEPARATOR.join(name_list)
     logger.info(f'execution_name={execution_name}')

--- a/lambda_functions/tre-sqs-sf-trigger/version.sh
+++ b/lambda_functions/tre-sqs-sf-trigger/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 docker_image_name=tre-sqs-sf-trigger
-docker_image_tag=2.0.3
+docker_image_tag=2.0.4
 # shellcheck disable=SC2034  # var imported elsewhere
 docker_image="${docker_image_name}":"${docker_image_tag}"

--- a/testing/tre_sqs_sf_trigger/README.md
+++ b/testing/tre_sqs_sf_trigger/README.md
@@ -1,0 +1,19 @@
+Creates a test message and runs the Lambda handler function locally to execute
+the specified Step Function (State Machine).
+
+```bash
+./run.sh \
+  "${state_machine_name}" \
+  "${provider_name} \
+  "${event_name} \
+  "${consignment_type}" \
+  "${message_parameters}" \
+  "${consignment_ref_key_path}" \
+  "${aws_profile_target}"
+
+# Given the following value for message_parameters:
+message_parameters='"a": {"b": {"c": "cr-2032"}}'
+
+# This consignment_ref_key_path would locate value cr-2032:
+consignment_ref_key_path='parameters.a.b.c'
+```

--- a/testing/tre_sqs_sf_trigger/run.py
+++ b/testing/tre_sqs_sf_trigger/run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+Module to run tre_sqs_sf_trigger.handler; see corresponding run.sh file.
+"""
+import tre_sqs_sf_trigger
+import sys
+import json
+
+if len(sys.argv) != 2:
+    raise ValueError('usage: tre_message')
+
+tre_message = json.loads(sys.argv[1])
+sns_message = {'Message': json.dumps(tre_message)}
+print(f'sns_message={sns_message}')
+
+event = {
+    'Records': [
+        {
+            'eventSourceARN': 'arn:aws:sqs:example:00example000:some-sqs-in',
+            'body': json.dumps(sns_message)
+        }
+    ]
+}
+
+result = tre_sqs_sf_trigger.handler(event=event, context=None)
+print(f'result:\n{result}')

--- a/testing/tre_sqs_sf_trigger/run.sh
+++ b/testing/tre_sqs_sf_trigger/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Run the tre_sqs_sf_trigger handler locally. Creates a TRE event string with
+# the given message_parameters and sends this to the handler, which is
+# configured to use the specified Step Function.
+#
+# Arguments:
+# state_machine_name       : The name of the Step Function that will be run
+# provider_name            : Generated message's provider name; e.g. `TRE`
+# event_name               : Generated message's event name; e.g. `bagit-available`
+# consignment_type         : Generated message's consignment type; e.g. `judgment`
+# message_parameters       : Parameters added to generated TRE message
+# consignment_ref_key_path : Where Lambda finds consignment ref in incoming
+#                            message parameter block; e.g.
+#                            'parameters.bagit-available.reference'
+# [aws_profile_target]     : Optional AWS profile name (defaults to AWS_PROFILE)
+set -e
+
+main() {
+  if [ $# -lt 6 ] || [ $# -gt 7 ]; then
+    echo "Usage: state_machine_name provider_name event_name consignment_type \
+message_parameters consignment_ref_key_path [aws_profile_target]"
+    return 1
+  fi
+
+  local state_machine_name="${1}"
+  local provider_name="${2}"
+  local event_name="${3}"
+  local consignment_type="${4}"
+  local message_parameters="${5}"
+  local consignment_ref_key_path="${6}"
+  local aws_profile_target="${7:-${AWS_PROFILE:?}}"
+
+  local query='stateMachines[?name==`'${state_machine_name}'`].stateMachineArn'
+  printf 'aws_profile_target="%s"\n' "${aws_profile_target}"
+  printf 'Query for State Machine "%s":\n%s\n' "${state_machine_name}" "${query}"
+  
+  local state_machine_arn
+  state_machine_arn="$(
+    aws --profile "${aws_profile_target}" \
+      stepfunctions list-state-machines \
+      --query "${query}" \
+      --output text
+  )"
+  
+  printf 'state_machine_arn="%s"\n' "${state_machine_arn:?}"
+
+  local message_uuid
+  message_uuid="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+  local uuid_list='[{"'"${provider_name}"'-UUID": "'"${message_uuid}"'"}]'
+  
+  message="$( \
+    ../v2_event_create.sh \
+      "${uuid_list}" \
+      "${provider_name}" \
+      'da-transform-judgments-pipeline/testing/tre_sqs_sf_trigger/run.sh' \
+      "${consignment_type}" \
+      'local' \
+      "${event_name}" \
+      "${message_parameters}"
+  )"
+  
+  printf 'Generated input message:\n%s\n' "${message}"
+
+  export TRE_STATE_MACHINE_ARN="${state_machine_arn}"
+  export TRE_CONSIGNMENT_KEY_PATH="${consignment_ref_key_path}"
+  export PYTHONPATH='../../lambda_functions/tre-sqs-sf-trigger'
+  
+  AWS_PROFILE="${aws_profile_target}" python3 run.py "${message}"
+}
+
+main "$@"


### PR DESCRIPTION
Retry number removed as retry is now to be handled by the central SNS mechanism (not dedicated retry SQS queues).

Also use `_` for any unknown value in a Step Function execution name (instead of `?`, which is not allowed).

Added developer test scripts.