### PR TITLE
Prevent marshal error, convert datetime to string

### DIFF
--- a/lambda_functions/tre-sqs-sf-trigger/tre_sqs_sf_trigger.py
+++ b/lambda_functions/tre-sqs-sf-trigger/tre_sqs_sf_trigger.py
@@ -223,4 +223,6 @@ def handler(event, context):
 
     # Completed OK, return details of any step function execution(s)
     logger.info('Completed OK; execution_ok_list=%s', execution_ok_list)
-    return execution_ok_list
+
+    # default=str to avoid "Object of type datetime is not JSON serializable"
+    return json.dumps(execution_ok_list, default=str)

--- a/lambda_functions/tre-sqs-sf-trigger/version.sh
+++ b/lambda_functions/tre-sqs-sf-trigger/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 docker_image_name=tre-sqs-sf-trigger
-docker_image_tag=2.0.5
+docker_image_tag=2.0.6
 # shellcheck disable=SC2034  # var imported elsewhere
 docker_image="${docker_image_name}":"${docker_image_tag}"


### PR DESCRIPTION
A marshalling error occurs when a Success step is added to a Step Function that is started by `tre_sqs_sf_trigger.py`.

This change aims to prevent that by coercing `datetime` objects in the returned execution summary payload to string values.