### PR TITLE
Prevent marshal error, convert datetime to string

### DIFF
--- a/lambda_functions/tre-forward/tre_forward.py
+++ b/lambda_functions/tre-forward/tre_forward.py
@@ -143,4 +143,4 @@ def lambda_handler(event, context):
 
     # Completed OK, return details of any step function execution(s)
     logger.info('Completed OK; forward_ok_list=%s', forward_ok_list)
-    return forward_ok_list
+    return json.dumps(forward_ok_list, default=str)

--- a/lambda_functions/tre-forward/version.sh
+++ b/lambda_functions/tre-forward/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 docker_image_name=tre-forward
-docker_image_tag=2.0.6
+docker_image_tag=2.0.7
 # shellcheck disable=SC2034  # var imported elsewhere
 docker_image="${docker_image_name}":"${docker_image_tag}"


### PR DESCRIPTION
I'm not sure a marshalling error will occur here, but to be on the safe side I'm opting to apply the same fix as [PR64](https://github.com/nationalarchives/da-transform-judgments-pipeline/pull/64).