### PR TITLE
DTE-317: latest tdr changes to bagit fields handled in bagit to dri sip

### DIFF
--- a/lambda_functions/tre-bagit-to-dri-sip/tre_bagit.py
+++ b/lambda_functions/tre-bagit-to-dri-sip/tre_bagit.py
@@ -72,22 +72,7 @@ class BagitData:
         # set dri batch/series/ prefix, escape the uri + append a `/` if folder
         dri_identifier = row.get('Filepath').replace('data/', dc["IDENTIFIER_PREFIX"], 1)
         final_slash_if_folder = "/" if(BagitData.dri_folder(row) == 'folder') else ""
-        print("+====> " + json.dumps(row))
-        print("+====> " + json.dumps(dc))
-        print("+===> " + dri_identifier)
-        result = urllib.parse.quote(dri_identifier).replace('%3A', ':') + final_slash_if_folder
-        print("+===> " + result)
-        return result
-
-    @staticmethod
-    def dri_legal_status(row):
-        # reword for Public Record
-        return 'Public Record(s)' if(row.get('LegalStatus') == 'Public Record') else row.get('LegalStatus')
-
-    @staticmethod
-    def dri_held_by(row):
-        # reword for TNA
-        return 'The National Archives, Kew' if(row.get('HeldBy') == 'TNA') else row.get('HeldBy')
+        return urllib.parse.quote(dri_identifier).replace('%3A', ':') + final_slash_if_folder
 
     def dri_checksum(self, row):
         # comes from the manifest and only exists for files

--- a/lambda_functions/tre-bagit-to-dri-sip/tre_bagit.py
+++ b/lambda_functions/tre-bagit-to-dri-sip/tre_bagit.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import json
+import logging
+import csv
+import io
+import urllib.parse
+import tre_bagit_transforms
+
+# Set global logging options; AWS environment may override this though
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+
+# Instantiate logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class BagitData:
+
+    def __init__(self, config_dict, info_dict, manifest_dict, csv_data):
+        self.bagit = config_dict
+        self.info_dict = info_dict
+        self.manifest_dict = manifest_dict
+        self.csv_data = list(csv_data)
+        self.consignment_series = self.info_dict.get('Consignment-Series')
+        self.tdr_bagit_export_time = self.info_dict.get('Consignment-Export-Datetime')
+
+    def to_metadata(self, dc):
+        metadata_fieldnames = ['identifier', 'file_name', 'folder', 'date_last_modified', 'checksum',
+                               'rights_copyright', 'legal_status', 'held_by', 'language', 'TDR_consignment_ref']
+        metadata_output = io.StringIO()
+        metadata_writer = csv.DictWriter(metadata_output, fieldnames=metadata_fieldnames, lineterminator="\n")
+        metadata_writer.writeheader()
+        for row in self.csv_data:
+            dri_metadata = tre_bagit_transforms.simple_dri_metadata(row)
+            result = self.dri_identifier(row, dc)
+            dri_metadata['identifier'] = result
+            dri_metadata['date_last_modified'] = self.dri_last_modified(row)
+            dri_metadata['checksum'] = self.dri_checksum(row)
+            dri_metadata['TDR_consignment_ref'] = self.bagit["CONSIGNMENT_REFERENCE"]
+            metadata_writer.writerow(dri_metadata)
+        return metadata_output.getvalue()
+
+    def to_closure(self, dc):
+        closure_fieldnames = ['identifier', 'folder', 'closure_start_date', 'closure_period', 'foi_exemption_code',
+                              'foi_exemption_asserted', 'title_public', 'title_alternate', 'closure_type']
+        closure_output = io.StringIO()
+        closure_writer = csv.DictWriter(closure_output, fieldnames=closure_fieldnames, lineterminator="\n")
+        closure_writer.writeheader()
+        for row in self.csv_data:
+            dri_closure = tre_bagit_transforms.simple_dri_closure(row)
+            dri_closure['identifier'] = self.dri_identifier(row, dc)
+            dri_closure['closure_start_date'] = ''
+            dri_closure['closure_period'] = 0
+            dri_closure['foi_exemption_asserted'] = ''
+            dri_closure['title_public'] = 'TRUE'
+            dri_closure['title_alternate'] = ''
+            dri_closure['closure_type'] = 'open_on_transfer'
+            closure_writer.writerow(dri_closure)
+        return closure_output.getvalue()
+
+    # ==== specific transformations for individual field values ====
+    @staticmethod
+    def dri_folder(row):
+        # remove capitalisation coming from tdr
+        return row.get('FileType').lower()
+
+    @staticmethod
+    def dri_identifier(row, dc):
+        # set dri batch/series/ prefix, escape the uri + append a `/` if folder
+        dri_identifier = row.get('Filepath').replace('data/', dc["IDENTIFIER_PREFIX"], 1)
+        final_slash_if_folder = "/" if(BagitData.dri_folder(row) == 'folder') else ""
+        print("+====> " + json.dumps(row))
+        print("+====> " + json.dumps(dc))
+        print("+===> " + dri_identifier)
+        result = urllib.parse.quote(dri_identifier).replace('%3A', ':') + final_slash_if_folder
+        print("+===> " + result)
+        return result
+
+    @staticmethod
+    def dri_legal_status(row):
+        # reword for Public Record
+        return 'Public Record(s)' if(row.get('LegalStatus') == 'Public Record') else row.get('LegalStatus')
+
+    @staticmethod
+    def dri_held_by(row):
+        # reword for TNA
+        return 'The National Archives, Kew' if(row.get('HeldBy') == 'TNA') else row.get('HeldBy')
+
+    def dri_checksum(self, row):
+        # comes from the manifest and only exists for files
+        bagit_manifest_for_row = list(filter(lambda d: d.get('file') == row.get('Filepath'), self.manifest_dict))
+        return bagit_manifest_for_row[0].get('checksum') if(len(bagit_manifest_for_row) == 1) else ''
+
+    def dri_last_modified(self, row):
+        if self.dri_folder(row) == 'file':
+            return row.get('LastModified')
+        else:
+            # use bagit export time for folders as they have no dlm from tdr
+            return self.tdr_bagit_export_time.replace('Z', '', 1)

--- a/lambda_functions/tre-bagit-to-dri-sip/tre_bagit_transforms.py
+++ b/lambda_functions/tre-bagit-to-dri-sip/tre_bagit_transforms.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+def simple_dri_metadata(bagit_metadata_row):
+    dri_metadata = {}
+    for k, v in bagit_metadata_row.items():
+        match k:
+            case 'Filepath':
+                pass  # used in a function to build dri 'identifier'
+            case 'FileName':
+                dri_metadata['file_name'] = v
+            case 'FileType':
+                match v:
+                    case 'File': dri_metadata['folder'] = 'file'
+                    case 'Folder': dri_metadata['folder'] = 'folder'
+                    case _: handle_error(k, v)
+
+            case 'Filesize':
+                pass  # not taken by dri
+            case 'RightsCopyright':
+                match v:
+                    case 'Crown Copyright': dri_metadata['rights_copyright'] = 'Crown Copyright'
+                    case _: handle_error(k, v)
+            case 'LegalStatus':
+                match v:  # the case match can be an OR as the output is the same
+                    case 'Public Record' | 'Public Record(s)': dri_metadata['legal_status'] = 'Public Record(s)'
+                    case _: handle_error(k, v)
+            case 'HeldBy':
+                match v:
+                    case 'TNA' | 'The National Archives, Kew': dri_metadata['held_by'] = 'The National Archives, Kew'
+                    case _: handle_error(k, v)
+            case 'Language':
+                match v:
+                    case 'English': dri_metadata['language'] = 'English'
+                    case _: handle_error(k, v)
+            case 'FoiExemptionCode':
+                pass  # not used in dri metadata file (related to closure)
+            case 'LastModified':
+                pass  # used in a function to build dri 'last_modified'
+            case 'OriginalFilePath':
+                pass  # not implemented yet
+            case _: handle_error(k, v)
+    return dri_metadata
+
+
+def simple_dri_closure(bagit_metadata_row):
+    dri_closure = {}
+    for k, v in bagit_metadata_row.items():
+        match k:
+            case 'FileType':
+                match v:
+                    case 'File': dri_closure['folder'] = 'file'
+                    case 'Folder': dri_closure['folder'] = 'folder'
+                    case _: handle_error(k, v)
+            case 'FoiExemptionCode':
+                match v:
+                    case '' | 'open': dri_closure['foi_exemption_code'] = 'open'
+                    case _: handle_error(k, v)
+            case 'RightsCopyright' | 'LegalStatus' | 'HeldBy' | 'Language' | 'LastModified' | 'FileName':
+                pass  # not used in closure
+            case 'Filepath':
+                pass  # used in a function to build dri 'identifier'
+            case 'Filesize':
+                pass  # not taken by dri
+            case 'OriginalFilePath':
+                pass  # not implemented yet
+            case _: handle_error(k, v)
+    return dri_closure
+
+
+def handle_error(k,v):
+    return ValueError("value " + v + "not expected for key " + k)

--- a/testing/tdr_sns_in_publish/README.md
+++ b/testing/tdr_sns_in_publish/README.md
@@ -7,7 +7,6 @@ Generate a sample TDR input message and publish this to the SNS input topic:
   "${s3_object_sha}"
   "${consignment_reference}"
   "${consignment_type}"
-  "${number_of_retries}"
   "${aws_profile_source}"
   "${aws_profile_target}"
 ```

--- a/testing/tre_bagit_to_dri_sip/run.sh
+++ b/testing/tre_bagit_to_dri_sip/run.sh
@@ -30,6 +30,7 @@ main() {
   AWS_TEST_FILE_PATH=${CONSIGNMENT}${consignment_type}/${consignment_reference}${TEST_UUID_DIRECTORY}${consignment_reference}
 
   #tmp clean up
+  rm -rf /tmp/tre-test/*
   aws s3 rm s3://"${s3_bucket_in}"/"${AWS_POST_TEST_PATH:?}" --recursive
   aws s3 rm s3://"${s3_bucket_out}"/"${AWS_POST_TEST_PATH:?}" --recursive
 


### PR DESCRIPTION
Small changes to values coming from TDR in some of the bagit fields
Refactored some of the transform so runs across every field in the metadata file in bagit (in prep for looking at "config" approaches).
Works (i.e diffs vs expected sips are ok) for:
- "old" bagits (e.g. test data TDR-2022-NQ3 and TDR-2022-AA1)
- "new" ones (e.g. test data TDR-2022-CXPN) as placed in the test data bucket.

