### PR TITLE
TRE-307: first unit tests / features for DPSG transforms

### DIFF
--- a/lambda_functions/tre-bagit-to-dri-sip/tre_bagit.py
+++ b/lambda_functions/tre-bagit-to-dri-sip/tre_bagit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import json
+
 import logging
 import csv
 import io
@@ -26,6 +26,7 @@ class BagitData:
         self.csv_data = list(csv_data)
         self.consignment_series = self.info_dict.get('Consignment-Series')
         self.tdr_bagit_export_time = self.info_dict.get('Consignment-Export-Datetime')
+        self.consignment_reference = self.info_dict.get('Internal-Sender-Identifier')
 
     def to_metadata(self, dc):
         metadata_fieldnames = ['identifier', 'file_name', 'folder', 'date_last_modified', 'checksum',
@@ -39,7 +40,7 @@ class BagitData:
             dri_metadata['identifier'] = result
             dri_metadata['date_last_modified'] = self.dri_last_modified(row)
             dri_metadata['checksum'] = self.dri_checksum(row)
-            dri_metadata['TDR_consignment_ref'] = self.bagit["CONSIGNMENT_REFERENCE"]
+            dri_metadata['TDR_consignment_ref'] = self.consignment_reference
             metadata_writer.writerow(dri_metadata)
         return metadata_output.getvalue()
 

--- a/lambda_functions/tre-bagit-to-dri-sip/tre_bagit_to_dri_sip.py
+++ b/lambda_functions/tre-bagit-to-dri-sip/tre_bagit_to_dri_sip.py
@@ -5,6 +5,7 @@ from s3_lib import checksum_lib
 from s3_lib import object_lib
 from s3_lib import tar_lib
 from tre_event_lib import tre_event_api
+from tre_bagit_transforms import dri_config_dict
 from tre_bagit import BagitData
 
 # Set global logging options; AWS environment may override this though
@@ -57,7 +58,7 @@ def handler(event, context):
         )
         # set-up config_dicts x 3 & make bagit data
         s3c = s3_config_dict(s3_object_root)
-        bc = bagit_config_dict(consignment_reference)
+        bc = bagit_config_dict
         info_dict = object_lib.s3_object_to_dictionary(s3_data_bucket, s3c["PREFIX_TO_BAGIT"] + bc["BAG_INFO_TEXT"])
         manifest_dict = checksum_lib.get_manifest_s3(s3_data_bucket, s3c["PREFIX_TO_BAGIT"] + bc["BAGIT_MANIFEST"])
         csv_data = object_lib.s3_object_to_csv(s3_data_bucket, s3c["PREFIX_TO_BAGIT"] + bc["BAGIT_METADATA"])
@@ -149,34 +150,8 @@ def handler(event, context):
         return event_output_error
 
 
-def dri_config_dict(consignment_reference, consignment_series):
-    metadata = 'metadata.csv'
-    closure = 'closure.csv'
-    consignment_reference_part = consignment_reference.split("-")
-    tdr_year = consignment_reference_part[1]
-    tdr_batch_number = consignment_reference_part[2]
-    batch = consignment_series.replace(' ', '') + 'Y' + tdr_year[2:] + 'TB' + tdr_batch_number
-    series = consignment_series.replace(' ', '_')
-    internal_prefix = batch + '/' + series + '/'
+def bagit_config_dict():
     return dict(
-        BATCH=batch,
-        SERIES=series,
-        INTERNAL_PREFIX=internal_prefix,
-        IDENTIFIER_PREFIX='file:/' + internal_prefix,
-        METADATA=metadata,
-        CLOSURE=closure,
-        METADATA_IN_SIP=internal_prefix + metadata,
-        CLOSURE_IN_SIP=internal_prefix + closure,
-        METADATA_SCHEMA_IN_SIP=internal_prefix + metadata + 's',
-        CLOSURE_SCHEMA_IN_SIP=internal_prefix + closure + 's',
-        METADATA_CHECKSUM_IN_SIP=internal_prefix + metadata + '.sha256',
-        CLOSURE_CHECKSUM_IN_SIP=internal_prefix + closure + '.sha256'
-    )
-
-
-def bagit_config_dict(consignment_reference):
-    return dict(
-        CONSIGNMENT_REFERENCE=consignment_reference,
         PREFIX_FOR_DATA='/data/',
         BAG_INFO_TEXT='/bag-info.txt',
         BAGIT_MANIFEST='/manifest-sha256.txt',

--- a/lambda_functions/tre-bagit-to-dri-sip/tre_bagit_to_dri_sip.py
+++ b/lambda_functions/tre-bagit-to-dri-sip/tre_bagit_to_dri_sip.py
@@ -58,7 +58,7 @@ def handler(event, context):
         )
         # set-up config_dicts x 3 & make bagit data
         s3c = s3_config_dict(s3_object_root)
-        bc = bagit_config_dict
+        bc = bagit_config_dict()
         info_dict = object_lib.s3_object_to_dictionary(s3_data_bucket, s3c["PREFIX_TO_BAGIT"] + bc["BAG_INFO_TEXT"])
         manifest_dict = checksum_lib.get_manifest_s3(s3_data_bucket, s3c["PREFIX_TO_BAGIT"] + bc["BAGIT_MANIFEST"])
         csv_data = object_lib.s3_object_to_csv(s3_data_bucket, s3c["PREFIX_TO_BAGIT"] + bc["BAGIT_METADATA"])

--- a/lambda_functions/tre-bagit-to-dri-sip/tre_bagit_transforms.py
+++ b/lambda_functions/tre-bagit-to-dri-sip/tre_bagit_transforms.py
@@ -75,5 +75,30 @@ def simple_dri_closure(bagit_metadata_row):
     return dri_closure
 
 
+def dri_config_dict(consignment_reference, consignment_series) -> object:
+    metadata = 'metadata.csv'
+    closure = 'closure.csv'
+    consignment_reference_part = consignment_reference.split("-")
+    tdr_year = consignment_reference_part[1]
+    tdr_batch_number = consignment_reference_part[2]
+    batch = consignment_series.replace(' ', '') + 'Y' + tdr_year[2:] + 'TB' + tdr_batch_number
+    series = consignment_series.replace(' ', '_')
+    internal_prefix = batch + '/' + series + '/'
+    return dict(
+        BATCH=batch,
+        SERIES=series,
+        INTERNAL_PREFIX=internal_prefix,
+        IDENTIFIER_PREFIX='file:/' + internal_prefix,
+        METADATA=metadata,
+        CLOSURE=closure,
+        METADATA_IN_SIP=internal_prefix + metadata,
+        CLOSURE_IN_SIP=internal_prefix + closure,
+        METADATA_SCHEMA_IN_SIP=internal_prefix + metadata + 's',
+        CLOSURE_SCHEMA_IN_SIP=internal_prefix + closure + 's',
+        METADATA_CHECKSUM_IN_SIP=internal_prefix + metadata + '.sha256',
+        CLOSURE_CHECKSUM_IN_SIP=internal_prefix + closure + '.sha256'
+    )
+
+
 def handle_error(k,v):
     return ValueError("value " + v + "not expected for key " + k)

--- a/testing/features/READ_ME.md
+++ b/testing/features/READ_ME.md
@@ -1,0 +1,13 @@
+# notes to run features and unit tests (will soon move lambda to own repo and so structure /running details tbc )
+
+## To run features
+install behave with:       `pip install behave`
+check installation with:   `behave --version`
+in `testing` directory:
+ `export PYTHONPATH=../lambda_functions/tre-bagit-to-dri-sip`
+  run with `behave` 
+
+## To run unit tests:
+in `testing/tre_bagit_to_dri_sip`
+ `export PYTHONPATH=../../lambda_functions/tre-bagit-to-dri-sip`
+  run with `python -m unittest discover`

--- a/testing/features/bagit_transform_v_1_1.feature
+++ b/testing/features/bagit_transform_v_1_1.feature
@@ -1,0 +1,113 @@
+Feature: Verify bagit transforms to dri closure.csv / metadata.csv.
+
+  Scenario: Verify a file's closure in TDR version 1.1
+
+    Given a bagit with files that include:
+      | File                | Field                          | Value                              |
+      | bag-info.txt        | Consignment-Series             | MOCKA 101                          |
+      | bag-info.txt        | Internal-Sender-Identifier     | TDR-2022-AA1                       |
+      | file-metadata.csv   | Filepath                       | data/content/folder-a/file-a1.txt  |
+      | file-metadata.csv   | FileType                       | File                               |
+      | file-metadata.csv   | FoiExemptionCode               | open                               |
+
+    When transform that bagit to make closure.csv
+
+    Then the file closure.csv has:
+      | Field                  | Value                                                            |
+      | identifier             | file:/MOCKA101Y22TBAA1/MOCKA_101/content/folder-a/file-a1.txt    |
+      | folder                 | file                                                             |
+      | closure_start_date     |                                                                  |
+      | closure_period         | 0                                                                |
+      | foi_exemption_code     | open                                                             |
+      | foi_exemption_asserted |                                                                  |
+      | title_public           | TRUE                                                             |
+      | title_alternate        |                                                                  |
+      | closure_type           | open_on_transfer                                                 |
+
+  Scenario: Verify a folder's closure in TDR version 1.1
+
+    Given a bagit with files that include:
+      | File                | Field                          | Value                              |
+      | bag-info.txt        | Consignment-Series             | MOCKA 101                          |
+      | bag-info.txt        | Internal-Sender-Identifier     | TDR-2022-AA1                       |
+      | file-metadata.csv   | Filepath                       | data/content/folder-a              |
+      | file-metadata.csv   | FileType                       | Folder                             |
+      | file-metadata.csv   | FoiExemptionCode               | open                               |
+
+    When transform that bagit to make closure.csv
+
+    Then the file closure.csv has:
+      | Field                  | Value                                                            |
+      | identifier             | file:/MOCKA101Y22TBAA1/MOCKA_101/content/folder-a/               |
+      | folder                 | folder                                                           |
+      | closure_start_date     |                                                                  |
+      | closure_period         | 0                                                                |
+      | foi_exemption_code     | open                                                             |
+      | foi_exemption_asserted |                                                                  |
+      | title_public           | TRUE                                                             |
+      | title_alternate        |                                                                  |
+      | closure_type           | open_on_transfer                                                 |
+
+  Scenario: Verify a file's metadata in TDR version 1.1
+
+    Given a bagit with files that include:
+      | File                | Field                          | Value                              |
+      | bag-info.txt        | Consignment-Series             | MOCKA 101                          |
+      | bag-info.txt        | Internal-Sender-Identifier     | TDR-2022-AA1                       |
+      | bag-info.txt        | Consignment-Export-Datetime    | 2022-07-18T12:45:45Z               |
+      | manifest-sha256.txt | checksum                       | 4ef13f1d2350fe1e9f79a88ec063031f65da834e8afdd0512e230544cca0a34b |
+      | manifest-sha256.txt | file                           | data/content/folder-a/file-a1.txt  |
+      | file-metadata.csv   | Filepath                       | data/content/folder-a/file-a1.txt  |
+      | file-metadata.csv   | FileType                       | File                               |
+      | file-metadata.csv   | LegalStatus                    | Public Record                      |
+      | file-metadata.csv   | HeldBy                         | TNA                                |
+      | file-metadata.csv   | FileName                       | file-a1.txt                        |
+      | file-metadata.csv   | LastModified                   | 2022-07-18T00:00:00                |
+      | file-metadata.csv   | RightsCopyright                | Crown Copyright                    |
+      | file-metadata.csv   | Language                       | English                            |
+
+    When transform that bagit to make metadata.csv
+
+    Then the file metadata.csv has:
+      | Field                  | Value                                                            |
+      | identifier             | file:/MOCKA101Y22TBAA1/MOCKA_101/content/folder-a/file-a1.txt    |
+      | file_name              | file-a1.txt                                                      |
+      | folder                 | file                                                             |
+      | date_last_modified     | 2022-07-18T00:00:00                                              |
+      | checksum               | 4ef13f1d2350fe1e9f79a88ec063031f65da834e8afdd0512e230544cca0a34b |
+      | rights_copyright       | Crown Copyright                                                  |
+      | legal_status           | Public Record(s)                                                 |
+      | held_by                | The National Archives, Kew                                       |
+      | language               | English                                                          |
+      | TDR_consignment_ref    | TDR-2022-AA1                                                     |
+
+
+  Scenario: Verify a folder's metadata in TDR version 1.1
+
+    Given a bagit with files that include:
+      | File                | Field                          | Value                              |
+      | bag-info.txt        | Consignment-Series             | MOCKA 101                          |
+      | bag-info.txt        | Internal-Sender-Identifier     | TDR-2022-AA1                       |
+      | bag-info.txt        | Consignment-Export-Datetime    | 2022-07-18T12:45:45Z               |
+      | file-metadata.csv   | Filepath                       | data/content/folder-a              |
+      | file-metadata.csv   | FileType                       | Folder                             |
+      | file-metadata.csv   | FileName                       | folder-a                           |
+      | file-metadata.csv   | LegalStatus                    | Public Record                      |
+      | file-metadata.csv   | HeldBy                         | TNA                                |
+      | file-metadata.csv   | RightsCopyright                | Crown Copyright                    |
+      | file-metadata.csv   | Language                       | English                            |
+
+    When transform that bagit to make metadata.csv
+
+    Then the file metadata.csv has:
+
+      | identifier             | file:/MOCKA101Y22TBAA1/MOCKA_101/content/folder-a/               |
+      | file_name              | folder-a                                                         |
+      | folder                 | folder                                                           |
+      | date_last_modified     | 2022-07-18T12:45:45                                              |
+      | checksum               |                                                                  |
+      | rights_copyright       | Crown Copyright                                                  |
+      | legal_status           | Public Record(s)                                                 |
+      | held_by                | The National Archives, Kew                                       |
+      | language               | English                                                          |
+      | TDR_consignment_ref    | TDR-2022-AA1                                                     |

--- a/testing/features/bagit_transform_v_1_2.feature
+++ b/testing/features/bagit_transform_v_1_2.feature
@@ -1,0 +1,118 @@
+Feature: Verify bagit transforms to dri closure.csv / metadata.csv.
+
+#  in version 1.2 of a TDR bagit we have changes:
+#    -- `TNA` is replaced by `"The National Archives, Kew"` in the `HeldBy` column
+#    -- `Public Record` is replaced by `Public Record(s)` in the `LegalStatus` column
+#    -- `open` is instead empty in the `FoiExemptionCode` column
+
+  Scenario: Verify a file's closure in TDR version 1.2
+
+    Given a bagit with files that include:
+      | File                | Field                          | Value                              |
+      | bag-info.txt        | Consignment-Series             | MOCKA 101                          |
+      | bag-info.txt        | Internal-Sender-Identifier     | TDR-2022-AA1                       |
+      | file-metadata.csv   | Filepath                       | data/content/folder-a/file-a1.txt  |
+      | file-metadata.csv   | FileType                       | File                               |
+      | file-metadata.csv   | FoiExemptionCode               |                                    |
+
+    When transform that bagit to make closure.csv
+
+    Then the file closure.csv has:
+      | Field                  | Value                                                            |
+      | identifier             | file:/MOCKA101Y22TBAA1/MOCKA_101/content/folder-a/file-a1.txt    |
+      | folder                 | file                                                             |
+      | closure_start_date     |                                                                  |
+      | closure_period         | 0                                                                |
+      | foi_exemption_code     | open                                                             |
+      | foi_exemption_asserted |                                                                  |
+      | title_public           | TRUE                                                             |
+      | title_alternate        |                                                                  |
+      | closure_type           | open_on_transfer                                                 |
+
+  Scenario: Verify a folder's closure in TDR version 1.2
+
+    Given a bagit with files that include:
+      | File                | Field                          | Value                              |
+      | bag-info.txt        | Consignment-Series             | MOCKA 101                          |
+      | bag-info.txt        | Internal-Sender-Identifier     | TDR-2022-AA1                       |
+      | file-metadata.csv   | Filepath                       | data/content/folder-a              |
+      | file-metadata.csv   | FileType                       | Folder                             |
+      | file-metadata.csv   | FoiExemptionCode               |                                    |
+
+    When transform that bagit to make closure.csv
+
+    Then the file closure.csv has:
+      | Field                  | Value                                                            |
+      | identifier             | file:/MOCKA101Y22TBAA1/MOCKA_101/content/folder-a/               |
+      | folder                 | folder                                                           |
+      | closure_start_date     |                                                                  |
+      | closure_period         | 0                                                                |
+      | foi_exemption_code     | open                                                             |
+      | foi_exemption_asserted |                                                                  |
+      | title_public           | TRUE                                                             |
+      | title_alternate        |                                                                  |
+      | closure_type           | open_on_transfer                                                 |
+
+  Scenario: Verify a file's metadata in TDR version 1.2
+
+    Given a bagit with files that include:
+      | File                | Field                          | Value                              |
+      | bag-info.txt        | Consignment-Series             | MOCKA 101                          |
+      | bag-info.txt        | Internal-Sender-Identifier     | TDR-2022-AA1                       |
+      | bag-info.txt        | Consignment-Export-Datetime    | 2022-07-18T12:45:45Z               |
+      | manifest-sha256.txt | checksum                       | 4ef13f1d2350fe1e9f79a88ec063031f65da834e8afdd0512e230544cca0a34b |
+      | manifest-sha256.txt | file                           | data/content/folder-a/file-a1.txt  |
+      | file-metadata.csv   | Filepath                       | data/content/folder-a/file-a1.txt  |
+      | file-metadata.csv   | FileType                       | File                               |
+      | file-metadata.csv   | LegalStatus                    | Public Record(s)                   |
+      | file-metadata.csv   | HeldBy                         | The National Archives, Kew         |
+      | file-metadata.csv   | FileName                       | file-a1.txt                        |
+      | file-metadata.csv   | LastModified                   | 2022-07-18T00:00:00                |
+      | file-metadata.csv   | RightsCopyright                | Crown Copyright                    |
+      | file-metadata.csv   | Language                       | English                            |
+
+    When transform that bagit to make metadata.csv
+
+    Then the file metadata.csv has:
+      | Field                  | Value                                                            |
+      | identifier             | file:/MOCKA101Y22TBAA1/MOCKA_101/content/folder-a/file-a1.txt    |
+      | file_name              | file-a1.txt                                                      |
+      | folder                 | file                                                             |
+      | date_last_modified     | 2022-07-18T00:00:00                                              |
+      | checksum               | 4ef13f1d2350fe1e9f79a88ec063031f65da834e8afdd0512e230544cca0a34b |
+      | rights_copyright       | Crown Copyright                                                  |
+      | legal_status           | Public Record(s)                                                 |
+      | held_by                | The National Archives, Kew                                       |
+      | language               | English                                                          |
+      | TDR_consignment_ref    | TDR-2022-AA1                                                     |
+
+
+  Scenario: Verify a folder's metadata in TDR version 1.2
+
+    Given a bagit with files that include:
+      | File                | Field                          | Value                              |
+      | bag-info.txt        | Consignment-Series             | MOCKA 101                          |
+      | bag-info.txt        | Internal-Sender-Identifier     | TDR-2022-AA1                       |
+      | bag-info.txt        | Consignment-Export-Datetime    | 2022-07-18T12:45:45Z               |
+      | file-metadata.csv   | Filepath                       | data/content/folder-a              |
+      | file-metadata.csv   | FileType                       | Folder                             |
+      | file-metadata.csv   | FileName                       | folder-a                           |
+      | file-metadata.csv   | LegalStatus                    | Public Record(s)                   |
+      | file-metadata.csv   | HeldBy                         | The National Archives, Kew         |
+      | file-metadata.csv   | RightsCopyright                | Crown Copyright                    |
+      | file-metadata.csv   | Language                       | English                            |
+
+    When transform that bagit to make metadata.csv
+
+    Then the file metadata.csv has:
+
+      | identifier             | file:/MOCKA101Y22TBAA1/MOCKA_101/content/folder-a/               |
+      | file_name              | folder-a                                                         |
+      | folder                 | folder                                                           |
+      | date_last_modified     | 2022-07-18T12:45:45                                              |
+      | checksum               |                                                                  |
+      | rights_copyright       | Crown Copyright                                                  |
+      | legal_status           | Public Record(s)                                                 |
+      | held_by                | The National Archives, Kew                                       |
+      | language               | English                                                          |
+      | TDR_consignment_ref    | TDR-2022-AA1                                                     |

--- a/testing/features/steps/steps.py
+++ b/testing/features/steps/steps.py
@@ -1,0 +1,97 @@
+import json
+
+from behave import *
+from tre_bagit import BagitData
+from tre_bagit_transforms import dri_config_dict
+import csv
+import shutil
+import os
+
+
+#before
+temp_dir = '/tmp/tre-test/features'
+file_metadata_path = f'{temp_dir}/file-metadata.csv'
+bag_info_path = f'{temp_dir}/bag-info.json'
+manifest_path = f'{temp_dir}/manifest.json'
+
+
+def make_clean_temp_dir(temp_dir):
+    try:
+        shutil.rmtree(temp_dir)
+    except OSError as e:
+        return IOError("Error: %s : %s" % (temp_dir, e.strerror))
+    os.makedirs(temp_dir, exist_ok=True)
+
+
+@given(u'a bagit with files that include')
+def step_impl(context):
+    info_dict = {}
+    manifest_dict = []
+    csv_dict = {}
+    manifest_row = {}
+    for file, k, v in context.table:
+        print(str(file))
+        if file == 'bag-info.txt':
+            info_dict[k] = v
+        elif file == 'file-metadata.csv':
+            csv_dict[k] = v
+        elif file == 'manifest-sha256.txt':
+            manifest_row[k] = v
+        else:
+            return ValueError("file " + file + " not implemented")
+    manifest_dict.append(manifest_row)
+
+    make_clean_temp_dir(temp_dir)
+
+    # make file-metadata csv file in temp_dir
+    with open(file_metadata_path, 'x') as file_metadata:
+        file_metadata_fieldnames = list(csv_dict.keys())
+        file_metadata_writer = csv.DictWriter(file_metadata, fieldnames=file_metadata_fieldnames, lineterminator="\n")
+        file_metadata_writer.writeheader()
+        file_metadata_writer.writerow(csv_dict)
+    # make bag-info json file in temp_dir
+    with open(bag_info_path, 'x') as bif:
+        bif.write(json.dumps(info_dict))
+    # make manifest json file in tmp file
+    with open(manifest_path, 'x') as mf:
+        mf.write(json.dumps(manifest_dict))
+
+
+@when(u'transform that bagit to make {output}')
+def step_impl(context, output):
+    config_dict = {}
+    # make the bagit from the files in temp_dir
+    with open(bag_info_path) as bif:
+        info_dict = json.load(bif)
+    with open(manifest_path) as mf:
+        manifest_row = json.load(mf)
+    with open(file_metadata_path) as file_metadata:
+        file_metadata = csv.DictReader(file_metadata)
+        bagit = BagitData(config_dict, info_dict, manifest_row, file_metadata)
+    # run the required transformation and write the csv file to temp_dir
+    dc = dri_config_dict(bagit.consignment_reference, bagit.consignment_series)
+    if output == dc['CLOSURE']:
+        closure = bagit.to_closure(dc)
+        closure_filename = dc['CLOSURE']
+        closure_csv_path = f'{temp_dir}/{closure_filename}'
+        with open(closure_csv_path, 'x') as closure_csv:
+            closure_csv.write(closure)
+    elif output == dc['METADATA']:
+        metadata = bagit.to_metadata(dc)
+        metadata_filename = dc['METADATA']
+        metadata_csv_path = f'{temp_dir}/{metadata_filename}'
+        with open(metadata_csv_path, 'x') as metadata_csv:
+            metadata_csv.write(metadata)
+
+
+
+@then(u'the file {file_name} has')
+def step_impl(context, file_name):
+    # read the required csv file from temp_dir and check values
+    with open(f'{temp_dir}/{file_name}') as csv_file:
+        file_metadata = csv.DictReader(csv_file)
+        row = next(file_metadata)
+        for k, v in context.table:
+            print("assert that key: " + k + " has expected value: " + v + " actual value is: " + row[k])
+            assert(row[k] == v)
+

--- a/testing/features/steps/steps.py
+++ b/testing/features/steps/steps.py
@@ -8,7 +8,6 @@ import shutil
 import os
 
 
-#before
 temp_dir = '/tmp/tre-test/features'
 file_metadata_path = f'{temp_dir}/file-metadata.csv'
 bag_info_path = f'{temp_dir}/bag-info.json'
@@ -84,7 +83,6 @@ def step_impl(context, output):
             metadata_csv.write(metadata)
 
 
-
 @then(u'the file {file_name} has')
 def step_impl(context, file_name):
     # read the required csv file from temp_dir and check values
@@ -94,4 +92,3 @@ def step_impl(context, file_name):
         for k, v in context.table:
             print("assert that key: " + k + " has expected value: " + v + " actual value is: " + row[k])
             assert(row[k] == v)
-

--- a/testing/features/steps/steps.py
+++ b/testing/features/steps/steps.py
@@ -15,10 +15,11 @@ manifest_path = f'{temp_dir}/manifest.json'
 
 
 def make_clean_temp_dir(temp_dir):
-    try:
-        shutil.rmtree(temp_dir)
-    except OSError as e:
-        return IOError("Error: %s : %s" % (temp_dir, e.strerror))
+    if os.path.exists(temp_dir):
+        try:
+            shutil.rmtree(temp_dir)
+        except OSError as e:
+            return IOError("Error: %s : %s" % (temp_dir, e.strerror))
     os.makedirs(temp_dir, exist_ok=True)
 
 

--- a/testing/tre_bagit_to_dri_sip/test_bagit_transforms.py
+++ b/testing/tre_bagit_to_dri_sip/test_bagit_transforms.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+from tre_bagit import BagitData
+import csv
+import io
+import unittest
+
+
+config_dict = {
+    "CONSIGNMENT_REFERENCE": "TDR-2022-AA1"
+}
+info_dict = {
+    "Consignment-Series": "MOCKA 101",
+    "Internal-Sender-Identifier": "TDR-2022-AA1",
+    "Consignment-Export-Datetime": "2022-07-18T12:45:45Z",
+}
+manifest_dict = [
+    {
+        "file": "data/content/file-c1.txt",
+        "basename": "file-c1.txt",
+        "checksum": "5bd8879fba139fed98c048261cb2a91d727ceafb27414cc54e21c26915e9e40f"
+    }
+]
+driConfig = dict(
+    IDENTIFIER_PREFIX='file:/' + "MOCKA101Y22TBAA1" + '/' + "MOCKA_101" + '/'
+)
+
+
+def make_bagit(csv_string):
+    csv_data = csv.DictReader(io.StringIO(csv_string))
+    return BagitData(config_dict, info_dict, manifest_dict, csv_data)
+
+
+csv_string_v_1_1 = """Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified\n""" + \
+                   """data/content/file-c1.txt,file-c1.txt,File,12825,Crown Copyright,Public Record,TNA,English,open,2022-09-29T15:10:20\n""" + \
+                   """data/content,content,Folder,,Crown Copyright,Public Record,TNA,English,open,\n"""
+
+#  in version 1.2 of a TDR bagit we have changes:
+#    -- `TNA` is replaced by `"The National Archives, Kew"` in the `HeldBy` column
+#    -- `Public Record` is replaced by `Public Record(s)` in the `LegalStatus` column
+#    -- `open` is instead empty in the `FoiExemptionCode` column
+
+csv_string_v_1_2 = """Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalFilePath\n""" + \
+                   """data/content/file-c1.txt,file-c1.txt,File,36,Crown Copyright,Public Record(s),"The National Archives, Kew",English,,2022-09-29T15:10:20,\n""" + \
+                   """data/content,content,Folder,,Crown Copyright,Public Record(s),"The National Archives, Kew",English,,,\n"""
+
+
+class TestBagitMethods(unittest.TestCase):
+
+    maxDiff = None
+
+    expected_metadata = """identifier,file_name,folder,date_last_modified,checksum,rights_copyright,legal_status,held_by,language,TDR_consignment_ref\n""" + \
+                        """file:/MOCKA101Y22TBAA1/MOCKA_101/content/file-c1.txt,file-c1.txt,file,2022-09-29T15:10:20,5bd8879fba139fed98c048261cb2a91d727ceafb27414cc54e21c26915e9e40f,Crown Copyright,Public Record(s),"The National Archives, Kew",English,TDR-2022-AA1\n""" + \
+                        """file:/MOCKA101Y22TBAA1/MOCKA_101/content/,content,folder,2022-07-18T12:45:45,,Crown Copyright,Public Record(s),"The National Archives, Kew",English,TDR-2022-AA1\n"""
+
+    def test_bag_1_1_to_metadata(self):
+        bagit = make_bagit(csv_string_v_1_1)
+        actual_metadata = bagit.to_metadata(driConfig)
+        self.assertEqual(actual_metadata, self.expected_metadata)
+
+    def test_bag_1_2_to_metadata(self):
+        bagit = make_bagit(csv_string_v_1_2)
+        actual_metadata = bagit.to_metadata(driConfig)
+        self.assertEqual(actual_metadata, self.expected_metadata)
+
+    expected_closure = """identifier,folder,closure_start_date,closure_period,foi_exemption_code,foi_exemption_asserted,title_public,title_alternate,closure_type\n""" + \
+                       """file:/MOCKA101Y22TBAA1/MOCKA_101/content/file-c1.txt,file,,0,open,,TRUE,,open_on_transfer\n""" + \
+                       """file:/MOCKA101Y22TBAA1/MOCKA_101/content/,folder,,0,open,,TRUE,,open_on_transfer\n"""
+
+    def test_bag_1_1_to_closure(self):
+        bagit = make_bagit(csv_string_v_1_1)
+        actual_closure = bagit.to_closure(driConfig)
+        self.assertEqual(actual_closure, self.expected_closure)
+
+    def test_bag_1_2_to_closure(self):
+        bagit = make_bagit(csv_string_v_1_2)
+        actual_closure = bagit.to_closure(driConfig)
+        self.assertEqual(actual_closure, self.expected_closure)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/tre_bagit_to_dri_sip/test_bagit_transforms.py
+++ b/testing/tre_bagit_to_dri_sip/test_bagit_transforms.py
@@ -6,9 +6,7 @@ import io
 import unittest
 
 
-config_dict = {
-    "CONSIGNMENT_REFERENCE": "TDR-2022-AA1"
-}
+config_dict = {}
 info_dict = {
     "Consignment-Series": "MOCKA 101",
     "Internal-Sender-Identifier": "TDR-2022-AA1",
@@ -21,7 +19,7 @@ manifest_dict = [
         "checksum": "5bd8879fba139fed98c048261cb2a91d727ceafb27414cc54e21c26915e9e40f"
     }
 ]
-driConfig = dict(
+dri_config = dict(
     IDENTIFIER_PREFIX='file:/' + "MOCKA101Y22TBAA1" + '/' + "MOCKA_101" + '/'
 )
 
@@ -55,12 +53,12 @@ class TestBagitMethods(unittest.TestCase):
 
     def test_bag_1_1_to_metadata(self):
         bagit = make_bagit(csv_string_v_1_1)
-        actual_metadata = bagit.to_metadata(driConfig)
+        actual_metadata = bagit.to_metadata(dri_config)
         self.assertEqual(actual_metadata, self.expected_metadata)
 
     def test_bag_1_2_to_metadata(self):
         bagit = make_bagit(csv_string_v_1_2)
-        actual_metadata = bagit.to_metadata(driConfig)
+        actual_metadata = bagit.to_metadata(dri_config)
         self.assertEqual(actual_metadata, self.expected_metadata)
 
     expected_closure = """identifier,folder,closure_start_date,closure_period,foi_exemption_code,foi_exemption_asserted,title_public,title_alternate,closure_type\n""" + \
@@ -69,12 +67,12 @@ class TestBagitMethods(unittest.TestCase):
 
     def test_bag_1_1_to_closure(self):
         bagit = make_bagit(csv_string_v_1_1)
-        actual_closure = bagit.to_closure(driConfig)
+        actual_closure = bagit.to_closure(dri_config)
         self.assertEqual(actual_closure, self.expected_closure)
 
     def test_bag_1_2_to_closure(self):
         bagit = make_bagit(csv_string_v_1_2)
-        actual_closure = bagit.to_closure(driConfig)
+        actual_closure = bagit.to_closure(dri_config)
         self.assertEqual(actual_closure, self.expected_closure)
 
 


### PR DESCRIPTION
- lambda code will move soon to own repo so structure / how to run tests not dealt with in detail. See README added here for how to run
- main ambition is to try and establish the feature files as a format for documentation and individual steps + whether to test the transform method or test in a broader "mocked" and/or "integration" style can evolve on the back of those feature files
- a couple of small refactors in the transform code (so a deploy should take place on back of this)... have run the "developer" test that diffs the generated output vs the expected output and ok in those for v1.1 and v1.2 bagits