### PR TITLE
Fixing tests

### DIFF
--- a/testing/features/READ_ME.md
+++ b/testing/features/READ_ME.md
@@ -4,10 +4,8 @@
 install behave with:       `pip install behave`
 check installation with:   `behave --version`
 in `testing` directory:
- `export PYTHONPATH=../lambda_functions/tre-bagit-to-dri-sip`
   run with `behave` 
 
 ## To run unit tests:
 in `testing/tre_bagit_to_dri_sip`
- `export PYTHONPATH=../../lambda_functions/tre-bagit-to-dri-sip`
   run with `python -m unittest discover`

--- a/testing/features/steps/steps.py
+++ b/testing/features/steps/steps.py
@@ -1,5 +1,7 @@
-import json
+import sys
+sys.path.append("../lambda_functions/tre-bagit-to-dri-sip")
 
+import json
 from behave import *
 from tre_bagit import BagitData
 from tre_bagit_transforms import dri_config_dict

--- a/testing/tre_bagit_to_dri_sip/test-bagit-to-dri-sip.py
+++ b/testing/tre_bagit_to_dri_sip/test-bagit-to-dri-sip.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-import tre_bagit_to_dri_sip
 import sys
+sys.path.append("../../lambda_functions/tre-bagit-to-dri-sip")
+
+import tre_bagit_to_dri_sip
 import json
 
 if len(sys.argv) != 2:

--- a/testing/tre_bagit_to_dri_sip/test_bagit_transforms.py
+++ b/testing/tre_bagit_to_dri_sip/test_bagit_transforms.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import sys
+sys.path.append("../../lambda_functions/tre-bagit-to-dri-sip")
 
 from tre_bagit import BagitData
 import csv


### PR DESCRIPTION
Updating Python path in tests to remove need to export path variables in the console